### PR TITLE
package.json: Declare Node 6 as minimum requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "tslint": "^5.5.0",
     "typescript": "^2.4.1"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "jest": {
     "mapCoverage": true,
     "moduleFileExtensions": [


### PR DESCRIPTION
This was not specified properly up until now