### PR TITLE
Drop support for Node 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6'
+- '10'
 
 script:
   - yarn run lint

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^3.8.2"
   },
   "engines": {
-    "node": ">=6"
+    "node": "10.* || >= 12.*"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
... because the Node team itself is no longer supporting them either.